### PR TITLE
Support role-based credentials

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,6 +26,10 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-health</artifactId>
+          </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
         </dependency>
         <!-- Logging -->
         <dependency>

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/HealthClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/HealthClient.java
@@ -1,5 +1,6 @@
 package com.beeva.trustedoverlord.clients;
 
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.health.AWSHealthAsync;

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/HealthClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/HealthClient.java
@@ -1,6 +1,5 @@
 package com.beeva.trustedoverlord.clients;
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.health.AWSHealthAsync;

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/HealthClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/HealthClient.java
@@ -27,7 +27,6 @@ public class HealthClient implements Client {
     public HealthClient(String profile) {
         this(AWSHealthAsyncClientBuilder
                 .standard()
-                    .withCredentials(new ProfileCredentialsProvider(profile))
                     .withRegion(Regions.US_EAST_1.getName())
                 .build());
     }

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/HealthClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/HealthClient.java
@@ -1,5 +1,10 @@
 package com.beeva.trustedoverlord.clients;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.auth.profile.ProfilesConfigFile;
+import com.amazonaws.auth.profile.internal.BasicProfile;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.regions.Regions;
@@ -27,13 +32,27 @@ public class HealthClient implements Client {
     public HealthClient(String profile) {
         this(AWSHealthAsyncClientBuilder
                 .standard()
-                    .withCredentials(new ProfileCredentialsProvider(profile))
+                    .withCredentials(getCredentialsProvider(profile))
                     .withRegion(Regions.US_EAST_1.getName())
                 .build());
     }
 
     private HealthClient(AWSHealthAsync client){
         this.client = client;
+    }
+
+    private static AWSCredentialsProvider getCredentialsProvider(String profile) {
+        BasicProfile basicProfile = new ProfilesConfigFile().getAllBasicProfiles().get(profile);
+        if(basicProfile == null) {
+            throw new RuntimeException("No AWS profile named '" + profile + "'");
+        }
+
+        if (basicProfile.isRoleBasedProfile()) {
+           return new STSAssumeRoleSessionCredentialsProvider.Builder(basicProfile.getRoleArn(), "healthClientSession")
+                       .withStsClient(AWSSecurityTokenServiceClientBuilder.defaultClient()).build();
+        } else {
+            return new ProfileCredentialsProvider(profile);
+        }
     }
 
     public CompletableFuture<ProfileHealth> getProfileHealth() {

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/HealthClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/HealthClient.java
@@ -27,6 +27,7 @@ public class HealthClient implements Client {
     public HealthClient(String profile) {
         this(AWSHealthAsyncClientBuilder
                 .standard()
+                    .withCredentials(new ProfileCredentialsProvider(profile))
                     .withRegion(Regions.US_EAST_1.getName())
                 .build());
     }

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/SupportClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/SupportClient.java
@@ -1,5 +1,6 @@
 package com.beeva.trustedoverlord.clients;
 
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.support.AWSSupportAsync;

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/SupportClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/SupportClient.java
@@ -1,6 +1,5 @@
 package com.beeva.trustedoverlord.clients;
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.support.AWSSupportAsync;

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/SupportClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/SupportClient.java
@@ -1,5 +1,10 @@
 package com.beeva.trustedoverlord.clients;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.auth.profile.ProfilesConfigFile;
+import com.amazonaws.auth.profile.internal.BasicProfile;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.regions.Regions;
@@ -26,13 +31,27 @@ public class SupportClient implements Client {
     public SupportClient(String profile) {
         this(AWSSupportAsyncClientBuilder
                 .standard()
-                    .withCredentials(new ProfileCredentialsProvider(profile))
+                    .withCredentials(getCredentialsProvider(profile))
                     .withRegion(Regions.US_EAST_1.getName())
                 .build());
     }
 
     private SupportClient(AWSSupportAsync client){
         this.client = client;
+    }
+
+    private static AWSCredentialsProvider getCredentialsProvider(String profile) {
+        BasicProfile basicProfile = new ProfilesConfigFile().getAllBasicProfiles().get(profile);
+        if(basicProfile == null) {
+            throw new RuntimeException("No AWS profile named '" + profile + "'");
+        }
+
+        if (basicProfile.isRoleBasedProfile()) {
+           return new STSAssumeRoleSessionCredentialsProvider.Builder(basicProfile.getRoleArn(), "supportClientSession")
+                       .withStsClient(AWSSecurityTokenServiceClientBuilder.defaultClient()).build();
+        } else {
+            return new ProfileCredentialsProvider(profile);
+        }
     }
 
     public CompletableFuture<ProfileSupportCases> getSupportCases() {

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/SupportClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/SupportClient.java
@@ -26,6 +26,7 @@ public class SupportClient implements Client {
     public SupportClient(String profile) {
         this(AWSSupportAsyncClientBuilder
                 .standard()
+                    .withCredentials(new ProfileCredentialsProvider(profile))
                     .withRegion(Regions.US_EAST_1.getName())
                 .build());
     }

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/SupportClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/SupportClient.java
@@ -26,7 +26,6 @@ public class SupportClient implements Client {
     public SupportClient(String profile) {
         this(AWSSupportAsyncClientBuilder
                 .standard()
-                    .withCredentials(new ProfileCredentialsProvider(profile))
                     .withRegion(Regions.US_EAST_1.getName())
                 .build());
     }

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/TrustedAdvisorClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/TrustedAdvisorClient.java
@@ -1,5 +1,6 @@
 package com.beeva.trustedoverlord.clients;
 
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.support.AWSSupportAsync;

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/TrustedAdvisorClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/TrustedAdvisorClient.java
@@ -1,6 +1,5 @@
 package com.beeva.trustedoverlord.clients;
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.support.AWSSupportAsync;

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/TrustedAdvisorClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/TrustedAdvisorClient.java
@@ -32,7 +32,6 @@ public class TrustedAdvisorClient implements Client {
     public TrustedAdvisorClient(String profile) {
         this(AWSSupportAsyncClientBuilder
                 .standard()
-                    .withCredentials(new ProfileCredentialsProvider(profile))
                     .withRegion(Regions.US_EAST_1.getName())
                 .build());
     }

--- a/core/src/main/java/com/beeva/trustedoverlord/clients/TrustedAdvisorClient.java
+++ b/core/src/main/java/com/beeva/trustedoverlord/clients/TrustedAdvisorClient.java
@@ -32,6 +32,7 @@ public class TrustedAdvisorClient implements Client {
     public TrustedAdvisorClient(String profile) {
         this(AWSSupportAsyncClientBuilder
                 .standard()
+                    .withCredentials(new ProfileCredentialsProvider(profile))
                     .withRegion(Regions.US_EAST_1.getName())
                 .build());
     }


### PR DESCRIPTION
In the absence of an explicitly set credentials provider, the SDK will
use [`DefaultAWSCredentialsProviderChain`](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html), which is more versatile than
[`ProfileCredentialsProvider`](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/profile/ProfileCredentialsProvider.html).  Looking through the code, I don't see any reason why this app needs to use `ProfileCredentialsProvider`.

From the `DefaultAWSCredentialsProviderChain` docs:

> AWS credentials provider chain that looks for credentials in this order:
> * Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (RECOMMENDED since they are recognized by all the AWS SDKs and CLI except for .NET), or AWS_ACCESS_KEY and AWS_SECRET_KEY (only recognized by Java SDK)
> * Java System Properties - aws.accessKeyId and aws.secretKey
> * Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI
> * Credentials delivered through the Amazon EC2 container service if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" environment variable is set and security manager has permission to access the variable,
> * Instance profile credentials delivered through the Amazon EC2 metadata service

This allows users to manage their credentials how they see fit -- in my case, while I do use profiles, they don't contain credentials (that's managed by another tool) and essentially act as labels.  `trusted-overlord` seems to work fine for me after this change.

It also paves the way to be able to deploy this tool in an automated fashion (say, on an instance, using the instance profile creds).
