### PR TITLE
Adding CLI usage and example to error message.

### DIFF
--- a/reporter/src/main/java/com/beeva/trustedoverlord/TrustedOverlordMain.java
+++ b/reporter/src/main/java/com/beeva/trustedoverlord/TrustedOverlordMain.java
@@ -17,6 +17,10 @@ public class TrustedOverlordMain {
 
         if (args.length < 1) {
             logger.error("Invalid number of arguments please provide at least one AWS profile name");
+            logger.error("Usage:");
+            logger.error("$ java -jar trustedoverlord-reporter.jar <aws_profile1> <aws_profile2> ...");
+            logger.error("Example:");
+            logger.error("$ java -jar trustedoverlord-reporter.jar myproject-dev myproject-prod anotherproject-dev anotherproject-prod");
             return;
         }
 


### PR DESCRIPTION
So I added a simple extended error message explaning the usage which should be trivial but error should be pedantic 

```java
[luix@boxita trusted-overlord]$ java -jar reporter/target/trustedoverlord-reporter-1.1.0-SNAPSHOT.jar 
2017-03-08T10:00:57,592 ERROR [main] c.b.t.TrustedOverlordMain: Invalid number of arguments please provide at least one AWS profile name
2017-03-08T10:00:57,594 ERROR [main] c.b.t.TrustedOverlordMain: Usage:
2017-03-08T10:00:57,594 ERROR [main] c.b.t.TrustedOverlordMain: $ java -jar trustedoverlord-reporter.jar <aws_profile1> <aws_profile2> ...
2017-03-08T10:00:57,594 ERROR [main] c.b.t.TrustedOverlordMain: Example:
2017-03-08T10:00:57,594 ERROR [main] c.b.t.TrustedOverlordMain: $ java -jar trustedoverlord-reporter.jar myproject-dev myproject-prod anotherproject-dev anotherproject-prod
[luix@boxita trusted-overlord]$ 
```